### PR TITLE
Support multiple users running RIPES' C-compiler.

### DIFF
--- a/src/ccmanager.cpp
+++ b/src/ccmanager.cpp
@@ -122,8 +122,9 @@ CCManager::CCRes CCManager::compile(const QStringList &files, QString outname,
                                     bool showProgressdiag) {
   CCRes res;
   if (outname.isEmpty()) {
+    const auto uuid = QUuid::createUuid();
     outname = QDir::tempPath() + QDir::separator() +
-              QCoreApplication::applicationName() + ".temp.out";
+              QCoreApplication::applicationName() + "." + uuid.toString(QUuid::Id128) + ".temp.out";
     QFile::remove(outname); // Remove any previously compiled file
   }
 

--- a/src/io/iomanager.cpp
+++ b/src/io/iomanager.cpp
@@ -222,6 +222,9 @@ void IOManager::updateSymbols() {
   if (m_symbolsHeaderFile->open(QIODevice::ReadWrite | QIODevice::Truncate)) {
     m_symbolsHeaderFile->write(headerfile.join('\n').toUtf8());
     m_symbolsHeaderFile->close();
+    // Set file permissions so RIPES ran by other users may read `ripes_system.h`
+    const auto permissions = QFileDevice::ReadOther | QFileDevice::ReadOwner | QFileDevice::WriteOwner;
+    m_symbolsHeaderFile->setPermissions(permissions);
   }
 }
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -176,7 +176,7 @@ QWidget *SettingsDialog::createCompilerPage() {
       new QLabel("Providing a compatible RISC-V C/C++ compiler enables "
                  "editing, compilation "
                  "and execution of C-language programs within Ripes.\n\n"
-                 "A compiler may be autodetected if availabe in PATH.");
+                 "A compiler may be autodetected if available in PATH.");
   CCDesc->setWordWrap(true);
   CCLayout->addWidget(CCDesc);
 


### PR DESCRIPTION
This is a workaround to permission issues due to `ripes_system.h` being
non-readable to other users, causing compilation to fail.

A UUID is also added to temporary compilation files on the off-chance
two people compile a program at the same time.